### PR TITLE
health condition values are usually percentages

### DIFF
--- a/Source/ThingQuery/Queries/QueryPawn.cs
+++ b/Source/ThingQuery/Queries/QueryPawn.cs
@@ -436,7 +436,7 @@ namespace TD_Find_Lib
 		public override bool DrawCustom(Rect rect, WidgetRow row, Rect fullRect)
 		{
 			if (sel != null && usesSeverity)
-				return TDWidgets.FloatRangeUB(fullRect.RightHalfClamped(row.FinalX), id, ref severityRange, valueStyle: ToStringStyle.FloatOne);
+				return TDWidgets.FloatRangeUB(fullRect.RightHalfClamped(row.FinalX), id, ref severityRange, valueStyle: ToStringStyle.PercentZero);
 
 			return false;
 		}


### PR DESCRIPTION
Trying to set up a condition on hypothermia being 0.2-0.3 is strange and also lacks precision. I don't know what this was this way, I couldn't find a condition that'd use such values (e.g. gunshot could be something like 1.2, but the UI condition for it doesn't even allow a range).